### PR TITLE
update workshop and minkube setup with new istio

### DIFF
--- a/documentation/DemoExposeRESTAPIs.md
+++ b/documentation/DemoExposeRESTAPIs.md
@@ -4,7 +4,7 @@ MicroProfile supports defining REST APIs via JAX-RS.
 
 The following sample shows the ‘web-api/v1/getmultiple‘ endpoint:
 
-```
+```java
 package com.ibm.webapi.apis;
  
 import javax.ws.rs.*;

--- a/documentation/IKSDeployment.md
+++ b/documentation/IKSDeployment.md
@@ -105,6 +105,10 @@ These are the instructions to install Istio. We used and tested Istio 1.5.1 for 
     curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.5.1 sh -
     ```
 
+    _Note:_ Please be aware that this does **not** work on Windows.
+    Windows users can download [istio-1.5.1-win.zip](https://github.com/istio/istio/releases/tag/1.5.1) here.
+    Unpack the ZIP file into the workshop directory and add the path to ```istio-1.5.1/bin``` your Windows **PATH**.
+
 1. Add `istioctl` to the PATH environment variable, e.g copy paste in your shell and/or `~/.profile`. Follow the instructions in the installer message.
 
 

--- a/documentation/SetupLocalEnvironment.md
+++ b/documentation/SetupLocalEnvironment.md
@@ -37,23 +37,23 @@ $ minikube stop
 
 ### Istio
 
-We used Istio 1.4.0 for this project. 
+We used Istio 1.5.1 for this project. 
 
-Note that the installation for Istio 1.4.0 has changed and also some commands, most notably those to open the Kiali, Jaeger, Prometheus, and Grafana dashboards were different in older Istio versions.
+Note that the installation for Istio 1.5.1 has changed and also some commands, most notably those to open the Kiali, Jaeger, Prometheus, and Grafana dashboards were different in older Istio versions.
 
 We will use `istioctl` to install Istio:
 
-1. Download Istio, this will create a directory istio-1.4.0:
+1. Download Istio, this will create a directory istio-1.5.1:
 
     ```
-    curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.4.0 sh -
+    curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.5.1 sh -
     ```
 
 2. Add `istioctl` to the PATH environment variable, e.g copy paste in your shell and/or `~/.profile`. Follow the instructions in the installer message.
 
 
     ```
-    export PATH="$PATH:/path/to/istio-1.4.0/bin"
+    export PATH="$PATH:/path/to/istio-1.5.1/bin"
     ```
 
 3. Verify the `istioctl` installation:

--- a/workshop/02-container.md
+++ b/workshop/02-container.md
@@ -558,12 +558,12 @@ With [sed](https://en.wikipedia.org/wiki/Sed_(Unix)) and [awk]( https://en.wikip
     2019-05-16 15:09:51 Sample API: curl http://159.122.172.162:31078/api/v1/getauthor?name=Niklas%20Heidloff
     2019-05-16 15:09:51 ------------------------------------------------------------------------------------
     2019-05-16 15:09:51 web-api
-    2019-05-16 15:09:51 API explorer: http://159.122.172.162:31380/openapi/ui/
+    2019-05-16 15:09:51 API explorer: http://159.122.172.162:31092/openapi/ui/
     2019-05-16 15:09:51 Metrics: http://159.122.172.162:32370/metrics/application
-    2019-05-16 15:09:51 Sample API: curl http://159.122.172.162:31380/web-api/v1/getmultiple
+    2019-05-16 15:09:51 Sample API: curl http://159.122.172.162:31092/web-api/v1/getmultiple
     2019-05-16 15:09:51 ------------------------------------------------------------------------------------
     2019-05-16 15:09:51 web-app
-    2019-05-16 15:09:52 Web app: http://159.122.172.162:31380/
+    2019-05-16 15:09:52 Web app: http://159.122.172.162:31092/
     2019-05-16 15:09:52 ------------------------------------------------------------------------------------
     ```
 
@@ -589,13 +589,13 @@ For the next steps use the results of the ```show-urls.sh``` script.
     $ {"name":"Niklas Heidloff","twitter":"@nheidloff","blog":"http://heidloff.net"}
     ```
 
-3. Open the API explorer **Web API** v1 in a browser http://YOUR_IP:31380/openapi/ui/
+3. Open the API explorer **Web API** v1 in a browser http://YOUR_IP:31092/openapi/ui/
 
 
     ![cns-container-articels-service-03](images/cns-container-web-api-v1-04.png)
 
 
-4. Open the the Application in a browser: http://YOUR_IP:31380/
+4. Open the the Application in a browser: http://YOUR_IP:31092/
 
     ![cns-container-web-app-04](images/cns-container-web-app-05.png)
 

--- a/workshop/03-rest-api.md
+++ b/workshop/03-rest-api.md
@@ -199,7 +199,7 @@ The following image shows an automatically created **Open API explorer** for the
 4. Verify that you can connect to your cluster by listing your worker nodes.
 
    ```sh
-   $ kubectl get nod
+   $ kubectl get nodes
    ```
 
 ---
@@ -233,12 +233,12 @@ In the following bash scripts we use **ibmcloud** and **kubectl** commands to in
 Now we invoke the following curl command of the **'Web API'** microservice. The IP is displayed as output of 'scripts/show-urls.sh'.
 
    ```sh
-   $ curl http://YOUR_IP:31380/web-api/v1/getmultiple
+   $ curl http://YOUR_IP:31092/web-api/v1/getmultiple
    ```
 After the execution of the command we should get following result:
 
    ```sh
-   $curl http://159.122.172.162:31380/web-api/v1/getmultiple
+   $curl http://159.122.172.162:31092/web-api/v1/getmultiple
    §[{"id":"1557993525215","title":"Debugging Microservices running in Kubernetes","url":"http://heidloff.net/article/debugging-microservices-kubernetes","authorName":"Niklas Heidloff","authorBlog":"http://heidloff.net","authorTwitter":"@nheidloff"},{"id":"1557993525210","title":"Dockerizing Java MicroProfile Applications","url":"http://heidloff.net/article/dockerizing-container-java-microprofile","authorName":"Niklas Heidloff","authorBlog":"http://heidloff.net","authorTwitter":"@nheidloff"},{"id":"1557993525204","title":"Install Istio and Kiali on IBM Cloud or Minikube","url":"https://haralduebele.blog/2019/02/22/install-istio-and-kiali-on-ibm-cloud-or-minikube/","authorName":"Harald Uebele","authorBlog":"https://haralduebele.blog","authorTwitter":"@harald_u"},{"id":"1557993525199","title":"Three awesome TensorFlow.js Models for Visual Recognition","url":"http://heidloff.net/article/tensorflowjs-visual-recognition","authorName":"Niklas Heidloff","authorBlog":"http://heidloff.net","authorTwitter":"@nheidloff"},{"id":"1557993525194","title":"Blue Cloud Mirror Architecture Diagrams","url":"http://heidloff.net/article/blue-cloud-mirror-architecture-diagrams","authorName":"Niklas Heidloff","authorBlog":"http://heidloff.net","authorTwitter":"@nheidloff"}]
    ```
 

--- a/workshop/04-traffic-management.md
+++ b/workshop/04-traffic-management.md
@@ -182,7 +182,7 @@ _Optional:_ You can verify the new **Web app** version in Kubernetes.
     
     _Note:_ If you use the **workshop Docker image for Windows**, you have of open **kiali** in a browser on the windows host.
     
-    ```http://{CLUSTER-IP}:31380/kiali/console/applications?namespaces=default```
+    ```http://{CLUSTER-IP}:31092/kiali/console/applications?namespaces=default```
 
 
 
@@ -197,7 +197,7 @@ _Optional:_ You can verify the new **Web app** version in Kubernetes.
     ![Kiali config](images/traffic-routing-deployment14.png)
 
 
-7. Open the **Web APP** in a new browser tab: http://YOUR_IP:31380/
+7. Open the **Web APP** in a new browser tab: http://YOUR_IP:31092/
 _Note:_ This is on of the links we get from the ```iks-scripts/show-urls.sh``` script.
 
    ![cns-container-web-app-04](images/cns-container-web-app-05.png)

--- a/workshop/05-resiliency.md
+++ b/workshop/05-resiliency.md
@@ -127,7 +127,7 @@ In the following bash scripts we use **ibmcloud** and **kubectl** commands to in
    $ ./iks-scripts/show-urls.sh
    ```
 
-2. Open the **Web APP** in a new browser tab: http://YOUR_IP:31380/
+2. Open the **Web APP** in a new browser tab: http://YOUR_IP:31092/
 
 _Note:_ You get this link as output of the ```iks-scripts/show-urls.sh``` script.
 


### PR DESCRIPTION
Signed-off-by: Carlos Santana <csantana@us.ibm.com>

Fixes #40 

- Fix problem deploying old version of istio 1.1.5
- Consistency on istio version cross iks and minikube
- Port number is different for istio ingress gateway
- refactor add istio section in workshop
- miscs